### PR TITLE
fix type name for enums in typing generator

### DIFF
--- a/Source/V8/Private/TypingGenerator.h
+++ b/Source/V8/Private/TypingGenerator.h
@@ -129,7 +129,7 @@ struct TokenWriter
 		else if (auto p = Cast<UEnumProperty>(Property))
 		{
 			generator.Export(p->GetEnum());
-			push(FV8Config::Safeify(p->GetName()));
+			push(FV8Config::Safeify(p->GetEnum()->GetName()));
 		}
 		else if (auto p = Cast<UMulticastDelegateProperty>(Property))
 		{


### PR DESCRIPTION
the property type is incorrect if the property is an enum.
for example:
in 
`declare class WindowsTargetSettings {...}`
`MinimumOSVersion: MinimumOSVersion;`
instead of
`MinimumOSVersion: EMinimumSupportedOS;`